### PR TITLE
Add categories to a drop down menu

### DIFF
--- a/state_2c_geonode/context_processors.py
+++ b/state_2c_geonode/context_processors.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2016 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from geonode.base.models import TopicCategory
+
+
+def resource_urls(request):
+    """Global values to pass to templates"""
+    defaults = dict(
+        CATEGORIES=TopicCategory.objects.all(),
+    )
+    return defaults

--- a/state_2c_geonode/settings.py
+++ b/state_2c_geonode/settings.py
@@ -1058,3 +1058,4 @@ try:
     from local_settings import *  # noqa
 except ImportError:
     pass
+TEMPLATES[0]['OPTIONS']['context_processors'].append('state_2c_geonode.context_processors.resource_urls')

--- a/state_2c_geonode/templates/site_base.html
+++ b/state_2c_geonode/templates/site_base.html
@@ -9,4 +9,12 @@ Add Tab for Third Party Apps
  <a href="{{ PROJECT_ROOT }}app">App</a>
 </li>
 {% endcomment %}
+  <li>
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Categories<i class="fa fa-angle-down fa-lg"></i></a>
+    <ul class="dropdown-menu">
+    {% for category in CATEGORIES %}
+      <li><a href="">{{category.gn_description}}</a></li>
+    {% endfor %}
+    </ul>
+  </li>
 {% endblock %}


### PR DESCRIPTION
## What does this PR do?
Add categories to a drop down menu
use the `TopicCategories` for now, there are additional categories, that
ned to be added but can simply be appended in the context_processor
the context_processor is needed to make the categories available to all
templates
### Screenshot
The screenshot shows the default settings, not the actual categories.
![bildschirmfoto 2017-08-19 um 15 17 06](https://user-images.githubusercontent.com/688980/29617135-0832050e-8814-11e7-96b0-8044d3814526.png)

### Still to do/check
the settings need to be updated with the current settings it does not
work. the stripped down version from simod does work but I did not
include them here since this would be a big change and need to be
evaluated first